### PR TITLE
dpp: add version 10.0.35

### DIFF
--- a/recipes/dpp/all/conandata.yml
+++ b/recipes/dpp/all/conandata.yml
@@ -1,4 +1,8 @@
 sources:
+  "10.0.35":
+    url:
+    - "https://github.com/brainboxdotcc/DPP/archive/refs/tags/v10.0.35.zip"
+    sha256: "ebe82b0c3c7678d31bc26ad7ab9aedfd66057a559c541750ede5d19a0ed0c245"
   "10.0.34":
     url:
     - "https://github.com/brainboxdotcc/DPP/archive/refs/tags/v10.0.34.zip"

--- a/recipes/dpp/config.yml
+++ b/recipes/dpp/config.yml
@@ -1,3 +1,5 @@
 versions:
+  "10.0.35":
+    folder: all
   "10.0.34":
     folder: all


### PR DESCRIPTION
### Summary

Changes to recipe: **dpp/**

#### Motivation

This is an automatic update from our CI which adds the new version  of D++

#### Details

[Release announcement for D++ v](https://github.com/brainboxdotcc/DPP/releases/tag/v_VERSION_)

* [x]  Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md?rgh-link-date=2024-11-02T15%3A47%3A15Z)
* [x]  Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
* [x]  Tested locally with at least one configuration using a recent version of Conan

